### PR TITLE
vercel 404 fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"test": "jest",
 		"build": "tsc",
 		"build:watch": "yarn && tsc --w",
-		"prod": "yarn build && yarn dev"
+		"prod": "yarn build && node ./dist/index.js"
 	},
 	"dependencies": {
 		"bcrypt": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"test": "jest",
 		"build": "tsc",
 		"build:watch": "yarn && tsc --w",
-		"prod": "yarn build && yarn start"
+		"prod": "yarn build && yarn dev"
 	},
 	"dependencies": {
 		"bcrypt": "^5.1.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -117,7 +117,7 @@
 			"@middleware/*": ["middleware/*"]
 		},
 		"rootDir": "./src",
-		"outDir": "dist"
+		"outDir": "./dist"
 	},
 	"ts-node": {
 		"require": ["tsconfig-paths/register"]

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
 	"version": 2,
 	"builds": [
 		{
-			"src": "dist/index.js",
+			"src": "src/index.js",
 			"use": "@vercel/node",
 			"config": { "includeFiles": ["dist/**"] }
 		}
@@ -10,7 +10,7 @@
 	"routes": [
 		{
 			"src": "/(.*)",
-			"dest": "dist/index.js"
+			"dest": "/src/index.js"
 		}
 	]
 }


### PR DESCRIPTION
нужно на верселе чекнуть команду для сборки, должна быть yarn prod, если не работает то мб проблема в том что 	`"prod": "**yarn build** && node ./dist/index.js"`, мб придётся просто tsc написать